### PR TITLE
Support RC releases starting after 1.8.2

### DIFF
--- a/build_and_push.sh
+++ b/build_and_push.sh
@@ -5,8 +5,9 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 . utils.sh
 
-# Build tags passed in the command line or all tags.
-TAGS=${@:-`git tag | sort`}
+# Build tags passed in the command line or all tags starting at min version
+MIN_VERSION_TAG=${MIN_VERSION_TAG-"v1.8.2"}
+TAGS=${@:-$(git tag | tags_after $MIN_VERSION_TAG)}
 
 DOCKER_IMAGE=${DOCKER_IMAGE:-dockerswarm/dind}
 

--- a/update.sh
+++ b/update.sh
@@ -7,10 +7,15 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 DOCKER_REPOSITORY=https://github.com/docker/docker.git
 
-# Docker version tags starting from v1.0.0 excluding RCs
-DOCKER_VERSION_TAGS=$(git ls-remote --tags $DOCKER_REPOSITORY \
-	| cut -d$'\t' -f2 | cut -d'/' -f3 | grep -v "\^{}" \
-	| grep "^v1\." | grep -v -- "-rc" | sort)
+MIN_DOCKER_VERSION_TAG=${MIN_DOCKER_VERSION_TAG-"v1.8.2"}
+
+# Docker version tags starting from MIN_VERSION
+DOCKER_VERSION_TAGS=$(
+    git ls-remote --tags $DOCKER_REPOSITORY v\* |
+    awk -F'/' '{ print $3 }' |
+    grep -v "\^{}" |
+    tags_after $MIN_DOCKER_VERSION_TAG
+)
 
 function tag_exists() {
 	git rev-parse $1 >/dev/null 2>&1

--- a/utils.sh
+++ b/utils.sh
@@ -10,3 +10,12 @@ function run() {
 	echo "++ $@"
 	"$@"
 }
+
+# Sort versions correctly with rc releases. This will break if there
+# are more than 9 bug fix releases in a minor version
+function tags_after() {
+    local min_version=$1
+    sort -t"." -k "1,3.1Vr" -k "3.2,3.2" | \
+    sed "/^${min_version}\$/q" | \
+    sort -t"." -k "1,3.1V"  -k "3.2,3.2r"
+}


### PR DESCRIPTION
We want to use these images for the docker-compose test suite, and we also want to test against RC releases.

This adds support for updating and building RC releases. I set a min version of 1.8.2 so we don't go building images for all the past releases.
