### PR TITLE
add dockerd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV VERSION dev
 RUN curl -L -o /usr/local/bin/docker https://master.dockerproject.com/linux/amd64/docker \
     && chmod +x /usr/local/bin/docker
+RUN curl -L -o /usr/local/bin/dockerd https://master.dockerproject.com/linux/amd64/dockerd \
+    && chmod +x /usr/local/bin/dockerd
 RUN curl -L -o /usr/local/bin/docker-runc https://master.dockerproject.com/linux/amd64/docker-runc \
     && chmod +x /usr/local/bin/docker-runc
 RUN curl -L -o /usr/local/bin/docker-containerd https://master.dockerproject.com/linux/amd64/docker-containerd \


### PR DESCRIPTION
Now that the binary is splitted into two (client/daemon). `docker daemon` redirects to `dockerd`.

ping @vieux 

Signed-off-by: Alexandre Beslic alexandre.beslic@gmail.com
